### PR TITLE
Layout Persistance

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,21 +30,34 @@ export default {
   },
   data: function() {
     return {
-      layout: [
-        {"x":0,"y":0,"w":2,"h":5,"i":"0", "Name": "clock", "Config": {"Location":"Local"}},
-        {"x":2,"y":0,"w":2,"h":4,"i":"1", "Name": "weather", "Config": {"apiKey":"123", "zip":46530}},
-        {"x":4,"y":0,"w":2,"h":5,"i":"2", "Name": "weather", "Config": {"apiKey":"123", "zip":46530}},
-        {"x":6,"y":0,"w":2,"h":5,"i":"3", "Name": "clock", "Config": {"Location":"Local"}}
-        ],
+      // layout: [
+      //   {"x":0,"y":0,"w":2,"h":5,"i":"0", "Name": "clock", "Config": {"Location":"America/New_York"}},
+      //   {"x":2,"y":0,"w":2,"h":4,"i":"1", "Name": "weather", "Config": {"apiKey":"123", "zip":46530}},
+      //   {"x":4,"y":0,"w":2,"h":5,"i":"2", "Name": "weather", "Config": {"apiKey":"123", "zip":46530}},
+      //   {"x":6,"y":0,"w":2,"h":5,"i":"3", "Name": "clock", "Config": {"Location":"America/New_York"}}
+      //   ],
+      layout : [],
       edit: true
     }
-  }, created() {
-    axios.get("http://" + serverIP + "/layouts?name=main").then(response => console.log(response.data));
+  }, beforeCreate() {
+    axios.get("http://" + serverIP + "/layouts?name=main").then(response => {
+      if (response.data.List){
+        this.layout = response.data.List;
+      } else {
+        this.layout = []
+      }
+    });
   },
   methods: {
+    uuidv4 : function() {
+      return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+        (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+      );
+    },
     addWidget : function() {
       const key = this.layout.length.toString();
-      this.layout.push({"x":0,"y":0,"w":2,"h":5,"i":key, "Name": "clock", "Config":{"Location":"Local"}})
+      const uuid = this.uuidv4();
+      this.layout.push({"x":0,"y":0,"w":2,"h":5,"i":key, "UUID": uuid, "Name": "clock", "Config":{"Location":"America/New_York"}})
     },
     editMode : function() {
       this.edit = !this.edit

--- a/src/components/CloseButton.vue
+++ b/src/components/CloseButton.vue
@@ -38,7 +38,7 @@ export default {
   methods: {
     close : function() {
       if (this.websocket){
-        this.websocket.send({"Action": "DELETE"});
+        this.websocket.send(JSON.stringify({"Action": "Delete"}));
         this.websocket.close();
       }
       this.$delete(this.layout, this.index);

--- a/src/components/Grid.vue
+++ b/src/components/Grid.vue
@@ -17,7 +17,11 @@
                      :w="item.w"
                      :h="item.h"
                      :i="item.i"
-                     :key="item.i"
+                     :key="item.UUID"
+                     @move="sendNewPosition(-1)"
+                     @moved="sendNewPosition(index)"
+                     @resize="sendNewPosition(-1)"
+                     @resized="sendNewPosition(index)"
                      class = "v-card v-sheet theme--light blue lighten-4"
                      >
         <Widget @changeConfig="changeConfig"
@@ -25,7 +29,8 @@
                 :index="index"
                 :edit="edit"
                 :item="item"
-                :key="index+item.Name"
+                :uuid="item.UUID"
+                :positionUpdate="positionUpdate"
         ></Widget>
       </GridItem>
     </GridLayout>
@@ -43,6 +48,10 @@ export default {
     }, edit:{
       required: true
     }
+  }, data : function() {
+    return {
+      positionUpdate : 0
+    }
   },
   components: {
       GridLayout: VueGridLayout.GridLayout,
@@ -51,6 +60,9 @@ export default {
   }, methods : {
     changeConfig : function(data) {
       this.$emit('changeConfig', data);
+    },
+    sendNewPosition : function(data) {
+      this.positionUpdate = data;
     }
   }
 }

--- a/src/components/constants/server_settings.js
+++ b/src/components/constants/server_settings.js
@@ -1,1 +1,1 @@
-export const serverIP = "10.26.127.25:9000";
+export const serverIP = "localhost:9000";

--- a/src/components/constants/widget_settings.js
+++ b/src/components/constants/widget_settings.js
@@ -1,8 +1,8 @@
 export var WidgetSettingsForm  = {
   'weather':
     [
-      {"apiLabel":"zip",   "label":"Zip*", "dataType" :"integer",    "data": ""},
-      {"apiLabel":"apiKey","label":"API Key*", "dataType": "string", "data": ""}
+      {"apiLabel":"Zip",   "label":"Zip*", "dataType" :"integer",    "data": ""},
+      {"apiLabel":"APIKey","label":"API Key*", "dataType": "string", "data": ""}
     ],
   'clock':
     [

--- a/src/components/widget_types/clock.vue
+++ b/src/components/widget_types/clock.vue
@@ -18,14 +18,17 @@
 </style>
 <script>
 export default {
-  name: 'TimeWidget',
+  name: 'ClockWidget',
   data: function(){
     return {
       time: "",
-      date: ""
+      date: "",
+      timeZone: this.api.Location
     }
   }, props:{
     sentData:{
+      required: true
+    }, api : {
       required: true
     }
   },
@@ -33,13 +36,14 @@ export default {
     sentData : function(){
       if (this.sentData.Status == "success"){
         var date_obj = new Date(Date.parse(this.sentData.Time));
-        this.time = date_obj.toLocaleTimeString('en-US');
-        this.date = date_obj.toLocaleDateString('en-US');
+        this.time = date_obj.toLocaleTimeString('en-US', {timeZone: this.timeZone});
+        this.date = date_obj.toLocaleDateString('en-US', {timeZone: this.timeZone});
       } else if (this.sentData.Status == "failure") {
         this.time = "N/A";
         this.date = "N/A";
       }
-
+    }, api : function() {
+      this.timeZone = this.api.Location;
     }
   }
 }


### PR DESCRIPTION
I changed some field names, again. But most importantly, I synced up the backend `/layouts` to our layouts. When the page loads, it performs a GET request to receive the stored layouts. It then will render all this information on the page. This led to other issues, however. When changing the configurations of a widget and when changing the type of the widget (weather to clock or clock to weather), we had to send that information to the server and have it digest correctly. 

Unfortunately, this made it so that we can't dynamically load widgets like we had before. Rather, we have to individually import them in `Widgets.vue` and add it to the components list. Not the end of the world, I think.