### PR TITLE
Clock Parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
   "dependencies": {
     "axios": "^0.19.2",
     "core-js": "^3.4.4",
+    "moment-timezone": "^0.5.27",
     "vue": "^2.6.10",
-    "vue-grid-layout": "^2.3.7"
+    "vue-grid-layout": "^2.3.7",
+    "vue-moment": "^4.1.0"
   },
   "devDependencies": {
     "@nuxtjs/vuetify": "^1.10.3",

--- a/src/components/widget_types/clock.vue
+++ b/src/components/widget_types/clock.vue
@@ -2,10 +2,20 @@
   <v-container>
     <v-row class="text-center">
       <v-col cols="12" class="pa-0">
-        <p class="mb-0">{{ time }}</p>
+        <p>{{ city }}</p>
+      </v-col>
+    </v-row>
+    <v-row v-if='timestamp != ""' class="text-center">
+      <v-col cols="12" class="pa-0">
+        <p class="mb-0">{{ timestamp | moment('timezone', timeZone , "h:mm:ss a")}}</p>
       </v-col>
       <v-col cols="12" class="pa-0">
-        <p class="mb-0">{{ date }}</p>
+        <p class="mb-0">{{ timestamp | moment('timezone', timeZone , "MMMM D YYYY") }}</p>
+      </v-col>
+    </v-row>
+    <v-row v-else class="text-center">
+      <v-col cols="12" class="pa-0">
+        <p class="mb-0">Failed to fetch time.</p>
       </v-col>
     </v-row>
   </v-container>
@@ -21,8 +31,7 @@ export default {
   name: 'ClockWidget',
   data: function(){
     return {
-      time: "",
-      date: "",
+      timestamp : "",
       timeZone: this.api.Location
     }
   }, props:{
@@ -31,20 +40,26 @@ export default {
     }, api : {
       required: true
     }
+  }, computed: {
+    city : function(){
+      try {
+        return this.timeZone.split("/")[1].replace(/_/g, " ");
+      } catch {
+        return this.timeZone;
+      }
+    }
   },
   watch : {
     // Run function on change of the sent data API
     sentData : function(){
       // If the API was successful
       if (this.sentData.Status == "success"){
-        var date_obj = new Date(Date.parse(this.sentData.Time));
-        this.time = date_obj.toLocaleTimeString('en-US', {timeZone: this.timeZone});
-        this.date = date_obj.toLocaleDateString('en-US', {timeZone: this.timeZone});
+        var data = this.sentData.Data;
+        this.timestamp = data.Time > 0 ? data.Time : "";
       }
        // If the API sent failed in some way
       else if (this.sentData.Status == "failure") {
-        this.time = "N/A";
-        this.date = "N/A";
+        this.timestamp = "";
       }
     }, api : function() {
       // If they change the clock Location

--- a/src/components/widget_types/weather.vue
+++ b/src/components/widget_types/weather.vue
@@ -41,9 +41,10 @@ export default {
       // If the API sent was successful
       if (this.sentData.Status=="success"){
         // Sets all the temperature data
-        this.temp = Math.round(this.sentData.Main.Temp) + "°F";
-        this.temp_min = Math.round(this.sentData.Main.TempMin) + "°F";
-        this.temp_max = Math.round(this.sentData.Main.TempMax) + "°F";
+        var data = this.sentData.Data;
+        this.temp = Math.round(data.Main.Temp) + "°F";
+        this.temp_min = Math.round(data.Main.TempMin) + "°F";
+        this.temp_max = Math.round(data.Main.TempMax) + "°F";
       } else {
         // Shows that we can't reach the API data
         this.temp = "N/A";

--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,12 @@ import Vue from 'vue'
 import App from './App.vue'
 // Importing vuetify
 import vuetify from './plugins/vuetify.js' // path to vuetify export
+import VueMoment from 'vue-moment'
+import moment from 'moment-timezone'
+
+Vue.use(VueMoment, {
+    moment,
+})
 
 Vue.config.productionTip = false
 


### PR DESCRIPTION
API structure changed. Now the base structure is {"status": "success", "data": {...}}. Had to change how we were parsing data in both clock.vue and weather.vue to account. Also clock connection now returns the unix timestamp, so adjusted using the timestamp and parsing it using a new library, moment.js, to help with parsing and displaying. 