### PR TITLE
example workflow for cd

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+on: 
+  pull_request:
+  push:
+
+jobs: 
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Compile and Build
+        run: npm install && npm run build
+      - uses: meeDamian/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: v0.0.1
+          allow_override: true
+          name: Pisign Frontend Release
+          body: The source code is packaged into zip files, while the compiled html / css / js / assets are avaliable in dist.tgz
+          files: dist/
+          gzip: folders


### PR DESCRIPTION
this will auto compile using `npm run build` when you push to master, and publish the `dist` folder to the releases as `dist.tgz`. This way people can just download the pre-compiled frontend to deploy to a raspberry pi or just to develop the backend with. 